### PR TITLE
Take Ghost's New Exporting Structure into Account

### DIFF
--- a/bin/jekyll_ghost_importer
+++ b/bin/jekyll_ghost_importer
@@ -10,7 +10,11 @@ FileUtils.mkdir_p("_drafts")
 
 json = JSON.parse File.read(ARGV.pop), symbolize_names: true
 
-posts = json[:data][:posts]
+unless json[:data].nil?
+  posts = json[:data][:posts]
+else
+  posts = json[:db].first[:data][:posts]
+end
 
 posts.each do |post|
   date = DateTime.parse(post[:published_at]) if post[:published_at]


### PR DESCRIPTION
The structure of Ghost's exported data has been changed somewhere along the line. This patch checks whether the 'posts' data is where it should be, if not, it tries to import according to the new structure. This is basically equivalent to the way Ghost's own import works with backward compatibility:

https://github.com/morficus/Ghost/commit/73539b0e8672f721bb8869e3c6a4d9df6bea3eed
