### PR TITLE
Add support for simple mobiledoc formatted markdown posts

### DIFF
--- a/bin/jekyll_ghost_importer
+++ b/bin/jekyll_ghost_importer
@@ -95,7 +95,19 @@ class Post
   end
 
   def full_body
-    front_matter.to_yaml + "---\n\n" + post[:markdown]
+    front_matter.to_yaml + "---\n\n" + markdown
+  end
+
+  def markdown
+    if post[:markdown]
+      post[:markdown]
+    elsif post[:mobiledoc]
+      mobiledoc = JSON.parse post[:mobiledoc], symbolize_names: true
+      card = mobiledoc[:cards].find { |c| c.first == "card-markdown" }
+      card.last[:markdown]
+    else
+      ""
+    end
   end
 
   def basename

--- a/features/import_posts.feature
+++ b/features/import_posts.feature
@@ -34,6 +34,37 @@ Feature: Import posts
     You're live!
     """
 
+  Scenario: Import a simple backup file with posts in mobiledoc format
+    Given a file named "GhostBackup.json" with:
+    """
+    {
+        "data": {
+            "posts": [
+                {
+                    "title": "Welcome to Ghost",
+                    "slug": "welcome-to-ghost",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"You're live with mobiledoc!\"}]],\"sections\":[[10,0]]}",
+                    "featured": 0,
+                    "status": "published",
+                    "published_at": "2014-02-21T01:14:57.000Z"
+                }
+            ]
+        }
+    }
+    """
+    When I run `jekyll_ghost_importer GhostBackup.json`
+    Then a directory named "_posts" should exist
+    Then the file "_posts/2014-02-21-welcome-to-ghost.markdown" should contain:
+    """
+    ---
+    layout: post
+    title: Welcome to Ghost
+    date: '2014-02-21 01:14:57'
+    ---
+
+    You're live with mobiledoc!
+    """
+
   Scenario: Import a backup file with two posts.
     Given a file named "GhostBackup.json" with:
     """


### PR DESCRIPTION
Ghost 1.0 uses a new format for posts where, instead of just storing the markdown, it stores the markdown as a "card" element in an embedded JSON string. If no text has been entered, the entire mobiledoc structure may be null.

This PR makes it possible to extract these into posts, making it compatible with the current version of Ghost and hopefully closing #8.