### PR TITLE
Change parser to prioritize html attribute over mobiledoc

### DIFF
--- a/bin/jekyll_ghost_importer
+++ b/bin/jekyll_ghost_importer
@@ -77,10 +77,12 @@ class Post < OpenStruct
   def markdown_body
     if markdown
       markdown
+    elsif html
+      markdown_from_html
     elsif mobiledoc
       mobiledoc_data = JSON.parse mobiledoc, symbolize_names: true
       markdown_card = mobiledoc_data[:cards].find { |c| c.first == "card-markdown" }
-      markdown_card ? markdown_card.last[:markdown] : markdown_from_html
+      markdown_card ? markdown_card.last[:markdown] : ""
     else
       ""
     end

--- a/features/fixtures/version-005.json
+++ b/features/fixtures/version-005.json
@@ -1,0 +1,87 @@
+{
+    "db": [
+      {
+        "meta": {
+          "exported_on": 1720851917028,
+          "version": "5.87.1"
+        },
+        "data": {
+          "posts": [
+            {
+              "id": "658e2b826de70700013de598",
+              "uuid": "8c66d0ed-cf5b-4a18-aeb1-c0c2ec44f8c6",
+              "title": "Moses: Responding to God’s call",
+              "slug": "moses-responding-to-gods-call",
+              "mobiledoc": null,
+              "html": "<p><em>This is an original lesson outline I prepared for one of my weekly Bible studies in 2023.</em></p><ul><li>We know how God has used Moses for the special assignment of leading the Israelites out of Egypt towards the Promised Land.</li><li>But before this, Moses had to be called by God. In the popular Sunday School story, God appeared to Moses in a burning bush (Exodus 3:1-10).</li><li>At first, Moses had many reservations about the call, even telling God to “please send someone else” (Exodus 4:13).</li><li>Like Moses, God has called us to fulfill certain assignments in life (family, career, business, etc), and we want to accomplish them in Jesus’ Name.&nbsp;</li><li>So today, we’ll look at how God responds to Moses’ reservations/excuses, which happen to parallel the same excuses we typically make when presented with these great dreams, goals, and plans God plants in our hearts.</li></ul>",
+              "feature_image": "https://images.unsplash.com/photo-1500670602153-5e2dd3c75f20?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDJ8fGJ1cm5pbmclMjBidXNofGVufDB8fHx8MTcwMzgxNzA1MXww&ixlib=rb-4.0.3&q=80&w=2000",
+              "featured": 0,
+              "type": "post",
+              "status": "published",
+              "locale": null,
+              "visibility": "public",
+              "email_recipient_filter": "all",
+              "created_at": "2023-12-29T02:14:26.000Z",
+              "updated_at": "2023-12-29T04:30:30.000Z",
+              "published_at": "2023-12-29T02:17:00.000Z",
+              "custom_excerpt": null,
+              "codeinjection_head": null,
+              "codeinjection_foot": null,
+              "custom_template": null,
+              "canonical_url": null,
+              "newsletter_id": null,
+              "show_title_and_feature_image": 1
+            }
+          ],
+          "posts_authors": [
+            {
+              "id": "658e2b826de70700013de599",
+              "post_id": "658e2b826de70700013de598",
+              "author_id": "1",
+              "sort_order": 0
+            }
+          ],
+          "posts_tags": [
+            {
+              "id": "658e32e96de70700013de5c5",
+              "post_id": "658e2b826de70700013de598",
+              "tag_id": "658e32e96de70700013de5c4",
+              "sort_order": 0
+            }
+          ],
+          "tags": [
+            {
+              "id": "658e32e96de70700013de5c4",
+              "name": "Bible study",
+              "slug": "bible-study",
+              "description": null,
+              "feature_image": null,
+              "parent_id": null,
+              "visibility": "public",
+              "og_image": null,
+              "og_title": null,
+              "og_description": null,
+              "twitter_image": null,
+              "twitter_title": null,
+              "twitter_description": null,
+              "meta_title": null,
+              "meta_description": null,
+              "codeinjection_head": null,
+              "codeinjection_foot": null,
+              "canonical_url": null,
+              "accent_color": null,
+              "created_at": "2023-12-29T02:46:01.000Z",
+              "updated_at": "2023-12-29T02:46:39.000Z"
+            }
+          ],
+          "users": [
+            {
+              "id": "1",
+              "name": "Chechu Siscar",
+              "slug": "chechu"
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/features/import_posts.feature
+++ b/features/import_posts.feature
@@ -319,6 +319,37 @@ Feature: Import posts
     [The Maker's Guide to the Zombie Apocalypse](http://amzn.to/1spRddk), a book written by Simon Monk (who I gather is quite well known within the maker community, having [authored various books](http://amzn.to/1spRqwW) on the Arduino and Raspberry Pi)
     """
 
+  Scenario: Import a backup file with version 004
+    Given a ghost backup file version 004 with some sample posts
+    When I run `jekyll_ghost_importer GhostBackup.json`
+    Then it should pass with:
+    """
+    Importing _posts/2023-12-29-moses-responding-to-gods-call.markdown
+    1 posts imported ( 0 draft )
+    """
+    And a directory named "_posts" should exist
+    And the following files should exist:
+      | _posts/2023-12-29-moses-responding-to-gods-call.markdown |
+    And the file "_posts/2023-12-29-moses-responding-to-gods-call.markdown" should contain:
+    """
+    ---
+    layout: post
+    title: 'Moses: Responding to God’s call'
+    date: '2023-12-29 02:17:00'
+    tags:
+    - bible-study
+    ---
+
+    _This is an original lesson outline I prepared for one of my weekly Bible studies in 2023._
+
+    - We know how God has used Moses for the special assignment of leading the Israelites out of Egypt towards the Promised Land.
+    - But before this, Moses had to be called by God. In the popular Sunday School story, God appeared to Moses in a burning bush (Exodus 3:1-10).
+    - At first, Moses had many reservations about the call, even telling God to “please send someone else” (Exodus 4:13).
+    - Like Moses, God has called us to fulfill certain assignments in life (family, career, business, etc), and we want to accomplish them in Jesus’ Name.&nbsp;
+    - So today, we’ll look at how God responds to Moses’ reservations/excuses, which happen to parallel the same excuses we typically make when presented with these great dreams, goals, and plans God plants in our hearts.
+
+    """
+
   Scenario: Import a draft with an invalid published_at date
     Given a file named "draft_with_invalid_date.json" with:
     """


### PR DESCRIPTION
Given the current format of the Ghost backup export, it makes sense to prioritize the `html` attribute over `mobiledoc` as the basis for post content. 

Under the current setup, when a post's `mobiledoc` attribute returns `null`, no post content is included in the Markdown files exported since the `markdown` attribute does not exist anymore as well.